### PR TITLE
Fix formatting in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-.venv/\n.env\n__pycache__/\nplaywright/.cache/
-.venv/\n.env\n__pycache__/\nplaywright/.cache/
+.venv/
+.env
+__pycache__/
+playwright/.cache/
+.DS_Store
+*.pyc


### PR DESCRIPTION
## Summary
- split `.gitignore` patterns onto separate lines
- ignore `.DS_Store` and `*.pyc`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684dc16058a4832c80ae9b5e9cd8b0d3