### PR TITLE
Switch login tests to Magento demo

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,9 +8,9 @@ from playwright.sync_api import expect, Page
 
 # ── Helper to decide if the user is already logged-in ──────────────────────
 def _is_logged_in(page: Page) -> bool:
-    # crude: look for the account menu text “Hi” in header
+    # crude: look for the account menu text "Sign Out" in header
     try:
-        return page.locator("text=Hi").first.is_visible(timeout=1_000)
+        return page.locator("text=Sign Out").first.is_visible(timeout=1_000)
     except Exception:
         return False
 
@@ -19,29 +19,28 @@ def _is_logged_in(page: Page) -> bool:
 @pytest.fixture(scope="session")
 def auth_context(browser) -> Page | None:
     """
-    If EBAY_USER / EBAY_PASS env vars exist, log in once and
+    If MAGENTO_USER / MAGENTO_PASS env vars exist, log in once and
     return a Page that stays logged-in for the whole test run.
     If creds are absent, return None so auth-required tests can skip.
     """
-    user = os.getenv("EBAY_USER")
-    pw   = os.getenv("EBAY_PASS")
+    user = os.getenv("MAGENTO_USER")
+    pw   = os.getenv("MAGENTO_PASS")
 
     if not (user and pw):
         return None  # no creds → tests that rely on login must skip
 
     page = browser.new_page()
-    page.goto("https://www.ebay.com/")
+    page.goto("https://magento.softwaretestingboard.com/")
 
     # avoid re-logging if session cookies already valid
     if not _is_logged_in(page):
-        page.goto("https://signin.ebay.com/")
-        page.fill("#userid", user)
-        page.click("#signin-continue-btn")
+        page.goto("https://magento.softwaretestingboard.com/customer/account/login/")
+        page.fill("#email", user)
         page.fill("#pass", pw)
-        page.click("#sgnBt")
+        page.click("#send2")
 
     # confirm we actually landed in the account-logged state
-    expect(page).to_have_url(re.compile(r"ebay\.com"), timeout=10_000)
+    expect(page).to_have_url(re.compile(r"magento\.softwaretestingboard\.com"), timeout=10_000)
     yield page
     page.close()
 
@@ -55,5 +54,5 @@ def logged_page(auth_context: Page | None, page: Page) -> Page:
     Usage in test:  def test_xyz(logged_page):
     """
     if auth_context is None:
-        pytest.skip("Auth-only flow – set EBAY_USER / EBAY_PASS to run")
+        pytest.skip("Auth-only flow – set MAGENTO_USER / MAGENTO_PASS to run")
     return auth_context


### PR DESCRIPTION
## Summary
- use `MAGENTO_USER` and `MAGENTO_PASS` env vars
- update login URLs and selectors for the Magento demo site
- adjust logged-in check and skip message

## Testing
- `pip install -r requirements.txt`
- `playwright install --with-deps` *(fails: Domain forbidden)*
- `pytest -q` *(fails: collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_684dc5f732a4832c9ce65e8229d6d300